### PR TITLE
[기능개발] 등급관련 트리거와 봉사왕 관련 이벤트 제작

### DIFF
--- a/DB/Event/volunteerKing/월말 누적 봉사와 선정 및 월별봉사왕 선정 이벤트.sql
+++ b/DB/Event/volunteerKing/월말 누적 봉사와 선정 및 월별봉사왕 선정 이벤트.sql
@@ -1,0 +1,44 @@
+-- 이벤트를 활성화하기 위한 설정, 이걸 키기 위해서는 특정 권한의 계정이 필요
+-- 현재는 서버부팅마다 새로 해줘야 함-> 컴퓨터 부팅마다 새로 적용
+-- 나중에 mariaDB의 설정 파일에서 서버 부팅시 자동 적용하는 걸로 변경하는 것이 좋아 보임
+SET GLOBAL event_scheduler = ON;
+
+DELIMITER //
+
+CREATE EVENT ev_test_volunteer_king
+    ON SCHEDULE
+        EVERY 1 MONTH
+        STARTS (LAST_DAY(CURRENT_DATE) + INTERVAL '23:59:59' HOUR_SECOND)
+    DO
+    BEGIN
+        DECLARE top_user_id_total INT;
+        DECLARE top_time_total INT;
+        DECLARE top_user_id_month INT;
+        DECLARE top_time_month INT;
+
+        SELECT user_id, cumulative_volunteer_time
+        INTO top_user_id_total, top_time_total
+        FROM user
+        ORDER BY cumulative_volunteer_time DESC
+        LIMIT 1;
+
+        UPDATE volunteerKing
+        SET user_id = top_user_id_total,
+            volunteer_time = top_time_total
+        WHERE category = 0;
+
+        SELECT user_id, month_volunteer_time
+        INTO top_user_id_month, top_time_month
+        FROM user
+        ORDER BY month_volunteer_time DESC
+        LIMIT 1;
+
+        INSERT INTO volunteerKing (category, year, month, volunteer_time, user_id)
+        VALUES (1, YEAR(CURDATE()), MONTH(CURDATE()), top_time_month, top_user_id_month);
+
+        UPDATE user
+        SET month_volunteer_time = 0;
+    END//
+
+DELIMITER ;
+

--- a/DB/Trriger/rating/유저의 누적 봉사신경 변경에 따른 등급 변화 트리거.sql
+++ b/DB/Trriger/rating/유저의 누적 봉사신경 변경에 따른 등급 변화 트리거.sql
@@ -1,0 +1,28 @@
+DELIMITER //
+
+CREATE TRIGGER trg_user_before_update_rating
+    BEFORE UPDATE ON user
+    FOR EACH ROW
+BEGIN
+    DECLARE new_rating_id INT;
+
+    -- 누적 봉사시간이 변경된 경우에만 실행
+    IF NEW.cumulative_volunteer_time <> OLD.cumulative_volunteer_time THEN
+
+        -- 해당 누적 봉사시간에 맞는 등급 찾기 (일반회원만: id 0~3)
+        SELECT id
+        INTO new_rating_id
+        FROM rating
+        WHERE standard <= NEW.cumulative_volunteer_time
+          AND id BETWEEN 0 AND 3
+        ORDER BY standard DESC
+        LIMIT 1;
+
+        -- 등급 변경 필요시 NEW에 반영
+        IF new_rating_id IS NOT NULL AND new_rating_id <> OLD.rating_id THEN
+            SET NEW.rating_id = new_rating_id;
+        END IF;
+    END IF;
+END//
+
+DELIMITER ;


### PR DESCRIPTION
## 📄 작업 내용 요약
등급 관련 트리거: 누적 봉사시간 변경 시 회원의 등급 자동 변경(회원과 관련된 값만 적용)
봉사왕 관련 이벤트: 월말에 누적 봉사와 갱신 및 해당 월의 월별 봉사왕 추가(추후 업데이트 필요(현재 월 봉사시간 최대값이 0인경우나 동일값이 있는 경우 처리X), 누적 봉사왕도 마찬가지로 누적값이 동일한 경우에 대한 처리가 없음) + 월별 봉사시간 0으로 초기화

### 📎 Issue 번호
<!-- closed #번호 -->
